### PR TITLE
Move to a less verbose log

### DIFF
--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -324,8 +324,8 @@ handle_call({done, Host, Port, Ssl, Socket}, {Pid, _} = From, State) ->
             NewState;
         UnexpectedExc ->
             CloseStatus = (catch lhttpc_sock:close(Socket, Ssl)),
-            lager:notice("lhttpc_manager, unrecognized socket (close_status ~p) is done (error ~p)",
-                         [CloseStatus, UnexpectedExc]),
+            lager:info("lhttpc_manager, unrecognized socket (close_status ~p) is done (error ~p)",
+                       [CloseStatus, UnexpectedExc]),
             State
     end,
     {noreply, FinalState};


### PR DESCRIPTION
There doesn't seem to be a way to find out the "issue" occurred, so no recovery strategy is
  possible.